### PR TITLE
chore: use an ubi9 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN    curl -L -o providers/keycloak-theme-rabe-$THEME_VERSION.jar \
     && /opt/keycloak/bin/kc.sh build
 
 
-FROM ghcr.io/radiorabe/ubi8-minimal:1.0.4
+FROM ghcr.io/radiorabe/ubi9-minimal:0.2.2
 
 # from https://github.com/keycloak/keycloak/blob/main/quarkus/container/Dockerfile#L25-L35
 RUN    microdnf install -y \


### PR DESCRIPTION
This is mostly in prep for #9 but there is no reason why it would break kc20