### PR TITLE
chore(ci): configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,22 @@
-
 version: 2
 updates:
-  - package-ecosystem: "docker"
-    directory: "/"
+  - package-ecosystem: docker
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     commit-message:
-      prefix: "feat: "
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      prefix: "chore: "
+    groups:
+      baseimages:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     commit-message:
       prefix: "chore(ci): "
-    open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
# Initialize [GitHub Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates).

Configures Dependabot to create regular update PRs.
